### PR TITLE
Increase Waybar module intervals

### DIFF
--- a/waybar/.config/waybar/config.jsonc
+++ b/waybar/.config/waybar/config.jsonc
@@ -37,12 +37,12 @@
   },
   "cpu": {
     "format": "<span color='#b2ccd6'>󰍛</span> {usage}%",
-    "interval": 2,
+    "interval": 10,
     "on-click": "kitty btop"
   },
   "memory": {
     "format": "<span color='#c792ea'>󰘚</span> {used:.2g}GB",
-    "interval": 2,
+    "interval": 10,
     "on-click": "kitty btop"
   },
   "group/control": {
@@ -68,7 +68,7 @@
     "format-wifi": "<span color='#89ddff'>{icon}</span> {signalStrength}% | {bandwidthDownBytes}",
     "format-disconnected": "<span color='#89ddff'>󰤭</span>",
     "format-icons": ["󰤯", "󰤟", "󰤢", "󰤥", "󰤨"],
-    "interval": 2,
+    "interval": 10,
     "tooltip-format": "{essid}",
     "on-click": "kitty nmtui"
   },


### PR DESCRIPTION
## Summary
- Increase update interval to 10 seconds for cpu, memory, and network modules in Waybar config

## Testing
- `make test` *(fails: No rule to make target 'test')*
- `pkill waybar && echo killed || echo no_process`
- `waybar >/tmp/waybar.log 2>&1 &` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a769287f38832d8ae9b6827be7029d