### PR TITLE
Clarify battery check interval

### DIFF
--- a/scripts/.config/scripts/bat_notify.sh
+++ b/scripts/.config/scripts/bat_notify.sh
@@ -19,5 +19,5 @@ while true; do
         fi
     fi
 
-    sleep 300  # check every minute
+    sleep 300  # check every 5 minutes
 done


### PR DESCRIPTION
## Summary
- clarify battery notification interval comment in bat_notify.sh

## Testing
- `systemctl --user restart bat_notify.service` *(fails: Failed to connect to bus: No medium found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7692bd0ac832dacbc4c1a5f3bacc4